### PR TITLE
fieldalignment: save some bytes in structs by aligning the padding fields

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -34,11 +34,11 @@ var (
 // Options for a slog.Handler that writes tinted logs. A zero Options consists
 // entirely of default values.
 type Options struct {
-	// Minimum level to log (Default: slog.InfoLevel)
-	Level slog.Level
-
 	// Time format (Default: time.StampMilli)
 	TimeFormat string
+
+	// Minimum level to log (Default: slog.InfoLevel)
+	Level slog.Level
 }
 
 // NewHandler creates a [slog.Handler] that writes tinted logs to w with the
@@ -66,14 +66,12 @@ func NewHandler(w io.Writer) slog.Handler {
 
 // handler implements a [slog.handler].
 type handler struct {
-	attrs  []byte
-	groups []byte
-
-	mu sync.Mutex
-	w  io.Writer // Output writer
-
-	level      slog.Level // Minimum level to log (Default: slog.InfoLevel)
-	timeFormat string     // Time format (Default: time.StampMilli)
+	w          io.Writer
+	timeFormat string
+	attrs      []byte
+	groups     []byte
+	level      slog.Level
+	mu         sync.Mutex
 }
 
 func (h *handler) clone() *handler {


### PR DESCRIPTION
/home/greyxor/Documents/Projects/tint/handler.go:36:14: struct with 16 pointer bytes could be 8
/home/greyxor/Documents/Projects/tint/handler.go:68:14: struct with 88 pointer bytes could be 64