### PR TITLE
Fix panic on tint.Err(nil)

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -312,7 +312,7 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groups string) {
 	}
 }
 
-func (h *handler) appendKey(buf *buffer, key string, groups string) {
+func (h *handler) appendKey(buf *buffer, key, groups string) {
 	buf.WriteStringIf(!h.noColor, ansiFaint)
 	appendString(buf, h.groups+groups+key, true)
 	buf.WriteByte('=')
@@ -377,4 +377,9 @@ func needsQuoting(s string) bool {
 type tintError struct{ error }
 
 // Err returns a tinted slog.Attr.
-func Err(err error) slog.Attr { return slog.Any(keyErr, tintError{err}) }
+func Err(err error) slog.Attr {
+	if err != nil {
+		err = tintError{err}
+	}
+	return slog.Any(keyErr, err)
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -238,6 +238,12 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 11 00:00:00.000 ERR test error=fail`,
 		},
+		{ // https://github.com/lmittmann/tint/issues/15
+			F: func(l *slog.Logger) {
+				l.Error("test", tint.Err(nil))
+			},
+			Want: `Nov 11 00:00:00.000 ERR test err=<nil>`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Closes: #15 

Testing `err == nil` didn't do the trick. I switched to recover which may recover other panic. If you have a better solution, I'm open.