### PR TITLE
Reset colors after message

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -184,6 +184,10 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 		buf.WriteByte(' ')
 	}
 
+	// Ensure color is reset before attrs in case message inherits colors from
+	// level.
+	buf.WriteStringIf(!h.noColor, ansiReset)
+
 	// write handler attributes
 	if len(h.attrs) > 0 {
 		buf.WriteString(h.attrs)


### PR DESCRIPTION
When message inherit level color, the first attr key inherits the color too. I suggest to always reset colors after message.

Here is a bug sample : the `role=` key should be faint white.

![image](https://user-images.githubusercontent.com/542613/233277056-dddc582d-07e0-401d-81e4-82dd58c20a7c.png)

@lmittmann What do you think of this ?