### PR TITLE
Run golangci-lint for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: latest
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true


### PR DESCRIPTION
Use https://github.com/golangci/golangci-lint via https://github.com/golangci/golangci-lint-action

Generally good to have, but soon interesting for 
* Go 1.21 support in https://github.com/lmittmann/tint/pull/23
* Upstream https://github.com/golangci/golangci-lint/issues/3933 and https://github.com/golangci/golangci-lint/pull/3922

I suggest to merge it to `main` branch before #23, then bring it to that PR branch (via merge or rebase) to have as a test baseline.

Feel free to see it in action in my fork:
* https://github.com/stefanb/tint/pull/1