### PR TITLE
Use Attr value for time in the case where a ReplaceAttr func has been passed in

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,7 @@ name: Go
 
 on:
   - push
+  - pull_request
 
 jobs:
   fmt_vet:

--- a/handler.go
+++ b/handler.go
@@ -179,7 +179,7 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 			buf.WriteByte(' ')
 		} else if a := rep(h.groups, slog.Time(slog.TimeKey, val)); a.Key != "" {
 			if a.Value.Kind() == slog.KindTime {
-				h.appendTime(buf, r.Time)
+				h.appendTime(buf, a.Value.Time())
 			} else {
 				appendValue(buf, a.Value, false)
 			}

--- a/handler_test.go
+++ b/handler_test.go
@@ -261,6 +261,20 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 10 23:00:00.000 ERR test err=<nil>`,
 		},
+		{ // https://github.com/lmittmann/tint/pull/26
+			Opts: &tint.Options{
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.TimeKey && len(groups) == 0 {
+						return slog.Time(slog.TimeKey, a.Value.Time().Add(24*time.Hour))
+					}
+					return a
+				},
+			},
+			F: func(l *slog.Logger) {
+				l.Error("test")
+			},
+			Want: `Nov 11 23:00:00.000 ERR test`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
* Use Attr value for time in the case where a ReplaceAttr func has been passed in.

Currently, if a ReplaceAttr function is specified on the Handler, any modified values of the TimeKey are ignored, and are read from the Record instead. This PR changes the behavior to use the (potentially modified) attribute time rather than the record time.