### PR TITLE
fix: inline Attrs for a group with an empty key

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -341,7 +341,9 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string) {
 
 	switch attr.Value.Kind() {
 	case slog.KindGroup:
-		groupsPrefix += attr.Key + "."
+		if attr.Key != "" {
+			groupsPrefix += attr.Key + "."
+		}
 		for _, groupAttr := range attr.Value.Group() {
 			h.appendAttr(buf, groupAttr, groupsPrefix)
 		}

--- a/handler_test.go
+++ b/handler_test.go
@@ -277,9 +277,9 @@ func TestHandler(t *testing.T) {
 		},
 		{ // https://github.com/lmittmann/tint/pull/27
 			F: func(l *slog.Logger) {
-				l.Info("msg", "a", "b", slog.Group("", slog.String("c", "d")), "e", "f")
+				l.Info("test", "a", "b", slog.Group("", slog.String("c", "d")), "e", "f")
 			},
-			Want: `Nov 10 23:00:00.000 INF msg a=b c=d e=f`,
+			Want: `Nov 10 23:00:00.000 INF test a=b c=d e=f`,
 		},
 	}
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -275,6 +275,12 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 11 23:00:00.000 ERR test`,
 		},
+		{
+			F: func(l *slog.Logger) {
+				l.Info("msg", "a", "b", slog.Group("", slog.String("c", "d")), "e", "f")
+			},
+			Want: `Nov 10 23:00:00.000 INF msg a=b c=d e=f`,
+		},
 	}
 
 	for i, test := range tests {

--- a/handler_test.go
+++ b/handler_test.go
@@ -275,7 +275,7 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 11 23:00:00.000 ERR test`,
 		},
-		{
+		{ // https://github.com/lmittmann/tint/pull/27
 			F: func(l *slog.Logger) {
 				l.Info("msg", "a", "b", slog.Group("", slog.String("c", "d")), "e", "f")
 			},


### PR DESCRIPTION
This fixes a bug where tint produces `.c=d` if the user passes an attribute like `slog.Group("", slog.String("c", "d"))`. This result violates one of slog's rules for handlers: "If a group's key is empty, inline the group's Attrs."