### PR TITLE
G104 (CWE-703): Errors unhandled.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -176,28 +176,28 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 		val := r.Time.Round(0) // strip monotonic to match Attr behavior
 		if rep == nil {
 			h.appendTime(buf, r.Time)
-			buf.WriteByte(' ')
+			_ = buf.WriteByte(' ')
 		} else if a := rep(h.groups, slog.Time(slog.TimeKey, val)); a.Key != "" {
 			if a.Value.Kind() == slog.KindTime {
 				h.appendTime(buf, a.Value.Time())
 			} else {
 				appendValue(buf, a.Value, false)
 			}
-			buf.WriteByte(' ')
+			_ = buf.WriteByte(' ')
 		}
 	}
 
 	// write level
 	if rep == nil {
 		h.appendLevel(buf, r.Level)
-		buf.WriteByte(' ')
+		_ = buf.WriteByte(' ')
 	} else if a := rep(h.groups, slog.Int(slog.LevelKey, int(r.Level))); a.Key != "" {
 		if a.Value.Kind() == slog.KindInt64 {
 			h.appendLevel(buf, slog.Level(a.Value.Int64()))
 		} else {
 			appendValue(buf, a.Value, false)
 		}
-		buf.WriteByte(' ')
+		_ = buf.WriteByte(' ')
 	}
 
 	// write source
@@ -213,26 +213,26 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 
 			if rep == nil {
 				h.appendSource(buf, src)
-				buf.WriteByte(' ')
+				_ = buf.WriteByte(' ')
 			} else if a := rep(h.groups, slog.Any(slog.SourceKey, src)); a.Key != "" {
 				appendValue(buf, a.Value, false)
-				buf.WriteByte(' ')
+				_ = buf.WriteByte(' ')
 			}
 		}
 	}
 
 	// write message
 	if rep == nil {
-		buf.WriteString(r.Message)
-		buf.WriteByte(' ')
+		_, _ = buf.WriteString(r.Message)
+		_ = buf.WriteByte(' ')
 	} else if a := rep(h.groups, slog.String(slog.MessageKey, r.Message)); a.Key != "" {
 		appendValue(buf, a.Value, false)
-		buf.WriteByte(' ')
+		_ = buf.WriteByte(' ')
 	}
 
 	// write handler attributes
 	if len(h.attrsPrefix) > 0 {
-		buf.WriteString(h.attrsPrefix)
+		_, _ = buf.WriteString(h.attrsPrefix)
 	}
 
 	// write attributes
@@ -287,9 +287,9 @@ func (h *handler) WithGroup(name string) slog.Handler {
 }
 
 func (h *handler) appendTime(buf *buffer, t time.Time) {
-	buf.WriteStringIf(!h.noColor, ansiFaint)
+	_, _ = buf.WriteStringIf(!h.noColor, ansiFaint)
 	*buf = t.AppendFormat(*buf, h.timeFormat)
-	buf.WriteStringIf(!h.noColor, ansiReset)
+	_, _ = buf.WriteStringIf(!h.noColor, ansiReset)
 }
 
 func (h *handler) appendLevel(buf *buffer, level slog.Level) {
@@ -297,40 +297,40 @@ func (h *handler) appendLevel(buf *buffer, level slog.Level) {
 		if val == 0 {
 			return
 		}
-		buf.WriteByte('+')
+		_ = buf.WriteByte('+')
 		*buf = strconv.AppendInt(*buf, int64(val), 10)
 	}
 
 	switch {
 	case level < slog.LevelInfo:
-		buf.WriteString("DBG")
+		_, _ = buf.WriteString("DBG")
 		delta(buf, level-slog.LevelDebug)
 	case level < slog.LevelWarn:
-		buf.WriteStringIf(!h.noColor, ansiBrightGreen)
-		buf.WriteString("INF")
+		_, _ = buf.WriteStringIf(!h.noColor, ansiBrightGreen)
+		_, _ = buf.WriteString("INF")
 		delta(buf, level-slog.LevelInfo)
-		buf.WriteStringIf(!h.noColor, ansiReset)
+		_, _ = buf.WriteStringIf(!h.noColor, ansiReset)
 	case level < slog.LevelError:
-		buf.WriteStringIf(!h.noColor, ansiBrightYellow)
-		buf.WriteString("WRN")
+		_, _ = buf.WriteStringIf(!h.noColor, ansiBrightYellow)
+		_, _ = buf.WriteString("WRN")
 		delta(buf, level-slog.LevelWarn)
-		buf.WriteStringIf(!h.noColor, ansiReset)
+		_, _ = buf.WriteStringIf(!h.noColor, ansiReset)
 	default:
-		buf.WriteStringIf(!h.noColor, ansiBrightRed)
-		buf.WriteString("ERR")
+		_, _ = buf.WriteStringIf(!h.noColor, ansiBrightRed)
+		_, _ = buf.WriteString("ERR")
 		delta(buf, level-slog.LevelError)
-		buf.WriteStringIf(!h.noColor, ansiReset)
+		_, _ = buf.WriteStringIf(!h.noColor, ansiReset)
 	}
 }
 
 func (h *handler) appendSource(buf *buffer, src *slog.Source) {
 	dir, file := filepath.Split(src.File)
 
-	buf.WriteStringIf(!h.noColor, ansiFaint)
-	buf.WriteString(filepath.Join(filepath.Base(dir), file))
-	buf.WriteByte(':')
-	buf.WriteString(strconv.Itoa(src.Line))
-	buf.WriteStringIf(!h.noColor, ansiReset)
+	_, _ = buf.WriteStringIf(!h.noColor, ansiFaint)
+	_, _ = buf.WriteString(filepath.Join(filepath.Base(dir), file))
+	_ = buf.WriteByte(':')
+	_, _ = buf.WriteString(strconv.Itoa(src.Line))
+	_, _ = buf.WriteStringIf(!h.noColor, ansiReset)
 }
 
 func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string) {
@@ -351,22 +351,22 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string) {
 		if err, ok := attr.Value.Any().(tintError); ok {
 			// append tintError
 			h.appendTintError(buf, err, groupsPrefix)
-			buf.WriteByte(' ')
+			_ = buf.WriteByte(' ')
 			break
 		}
 		fallthrough
 	default:
 		h.appendKey(buf, attr.Key, groupsPrefix)
 		appendValue(buf, attr.Value, true)
-		buf.WriteByte(' ')
+		_ = buf.WriteByte(' ')
 	}
 }
 
 func (h *handler) appendKey(buf *buffer, key, groups string) {
-	buf.WriteStringIf(!h.noColor, ansiFaint)
+	_, _ = buf.WriteStringIf(!h.noColor, ansiFaint)
 	appendString(buf, groups+key, true)
-	buf.WriteByte('=')
-	buf.WriteStringIf(!h.noColor, ansiReset)
+	_ = buf.WriteByte('=')
+	_, _ = buf.WriteStringIf(!h.noColor, ansiReset)
 }
 
 func appendValue(buf *buffer, v slog.Value, quote bool) {
@@ -399,19 +399,19 @@ func appendValue(buf *buffer, v slog.Value, quote bool) {
 }
 
 func (h *handler) appendTintError(buf *buffer, err error, groups string) {
-	buf.WriteStringIf(!h.noColor, ansiBrightRedFaint)
+	_, _ = buf.WriteStringIf(!h.noColor, ansiBrightRedFaint)
 	appendString(buf, h.groupPrefix+groups+errKey, true)
-	buf.WriteByte('=')
-	buf.WriteStringIf(!h.noColor, ansiResetFaint)
+	_ = buf.WriteByte('=')
+	_, _ = buf.WriteStringIf(!h.noColor, ansiResetFaint)
 	appendString(buf, err.Error(), true)
-	buf.WriteStringIf(!h.noColor, ansiReset)
+	_, _ = buf.WriteStringIf(!h.noColor, ansiReset)
 }
 
 func appendString(buf *buffer, s string, quote bool) {
 	if quote && needsQuoting(s) {
 		*buf = strconv.AppendQuote(*buf, s)
 	} else {
-		buf.WriteString(s)
+		_, _ = buf.WriteString(s)
 	}
 }
 


### PR DESCRIPTION
gosec complains about all `buf.Write*` function calls, which might return error that tint doesn't check.
While `_` doesn't change anything in golang execution, it is good reminder to users that these functions might return error.