### PR TITLE
fix: built-in attributes are not grouped

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -177,7 +177,7 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 		if rep == nil {
 			h.appendTime(buf, r.Time)
 			buf.WriteByte(' ')
-		} else if a := rep(h.groups, slog.Time(slog.TimeKey, val)); a.Key != "" {
+		} else if a := rep(nil /* groups */, slog.Time(slog.TimeKey, val)); a.Key != "" {
 			if a.Value.Kind() == slog.KindTime {
 				h.appendTime(buf, a.Value.Time())
 			} else {
@@ -191,7 +191,7 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 	if rep == nil {
 		h.appendLevel(buf, r.Level)
 		buf.WriteByte(' ')
-	} else if a := rep(h.groups, slog.Int(slog.LevelKey, int(r.Level))); a.Key != "" {
+	} else if a := rep(nil /* groups */, slog.Int(slog.LevelKey, int(r.Level))); a.Key != "" {
 		if a.Value.Kind() == slog.KindInt64 {
 			h.appendLevel(buf, slog.Level(a.Value.Int64()))
 		} else {
@@ -214,7 +214,7 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 			if rep == nil {
 				h.appendSource(buf, src)
 				buf.WriteByte(' ')
-			} else if a := rep(h.groups, slog.Any(slog.SourceKey, src)); a.Key != "" {
+			} else if a := rep(nil /* groups */, slog.Any(slog.SourceKey, src)); a.Key != "" {
 				appendValue(buf, a.Value, false)
 				buf.WriteByte(' ')
 			}
@@ -225,7 +225,7 @@ func (h *handler) Handle(_ context.Context, r slog.Record) error {
 	if rep == nil {
 		buf.WriteString(r.Message)
 		buf.WriteByte(' ')
-	} else if a := rep(h.groups, slog.String(slog.MessageKey, r.Message)); a.Key != "" {
+	} else if a := rep(nil /* groups */, slog.String(slog.MessageKey, r.Message)); a.Key != "" {
 		appendValue(buf, a.Value, false)
 		buf.WriteByte(' ')
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -119,6 +119,17 @@ func TestHandler(t *testing.T) {
 			Want: `INF test key=val`,
 		},
 		{
+			// drop built-in attributes in a grouped log
+			Opts: &tint.Options{
+				ReplaceAttr: drop(slog.TimeKey, slog.LevelKey, slog.MessageKey, slog.SourceKey),
+				AddSource:   true,
+			},
+			F: func(l *slog.Logger) {
+				l.WithGroup("foo").Info("test", "key", "val")
+			},
+			Want: `foo.key=val`,
+		},
+		{
 			Opts: &tint.Options{
 				ReplaceAttr: drop(slog.LevelKey),
 			},

--- a/handler_test.go
+++ b/handler_test.go
@@ -119,17 +119,6 @@ func TestHandler(t *testing.T) {
 			Want: `INF test key=val`,
 		},
 		{
-			// drop built-in attributes in a grouped log
-			Opts: &tint.Options{
-				ReplaceAttr: drop(slog.TimeKey, slog.LevelKey, slog.MessageKey, slog.SourceKey),
-				AddSource:   true,
-			},
-			F: func(l *slog.Logger) {
-				l.WithGroup("foo").Info("test", "key", "val")
-			},
-			Want: `foo.key=val`,
-		},
-		{
 			Opts: &tint.Options{
 				ReplaceAttr: drop(slog.LevelKey),
 			},
@@ -291,6 +280,17 @@ func TestHandler(t *testing.T) {
 				l.Info("test", "a", "b", slog.Group("", slog.String("c", "d")), "e", "f")
 			},
 			Want: `Nov 10 23:00:00.000 INF test a=b c=d e=f`,
+		},
+		{ // https://github.com/lmittmann/tint/pull/30
+			// drop built-in attributes in a grouped log
+			Opts: &tint.Options{
+				ReplaceAttr: drop(slog.TimeKey, slog.LevelKey, slog.MessageKey, slog.SourceKey),
+				AddSource:   true,
+			},
+			F: func(l *slog.Logger) {
+				l.WithGroup("group").Info("test", "key", "val")
+			},
+			Want: `group.key=val`,
 		},
 	}
 


### PR DESCRIPTION
Built-in attributes are not considered part of a logger's group
as specified by `WithGroup`.
Doing so means that if a user makes a log statement like the following,

    log.WithGroup("foo").Info("bar")

ReplaceAttr will be called with `groups = [foo]` for all built-in keys,
and therefore the [included code sample][1] for creating a logger
without the time key will not work.

  [1]: https://github.com/lmittmann/tint#customize-attributes

This change fixes invocations of ReplaceAttr to call it with
an empty groups slice for built-in attributes.

This matches the behavior of `log/slog`'s default handlers
which set `groups = nil` for the built-in attributes ([src][2])
before restoring it for non-built-ins ([src][3]).

  [2]: https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/log/slog/handler.go;l=265-266
  [3]: https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/log/slog/handler.go;l=300-301

Includes tests for omitting all built-in attributes.
