### PR TITLE
added option to change level labels

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -104,6 +104,9 @@ type Options struct {
 
 	// Disable color (Default: false)
 	NoColor bool
+
+	// Labels used for each label (Default: DBG,INF,WRN,ERR)
+	Labels [4]string
 }
 
 // NewHandler creates a [slog.Handler] that writes tinted logs to Writer w,
@@ -127,6 +130,15 @@ func NewHandler(w io.Writer, opts *Options) slog.Handler {
 		h.timeFormat = opts.TimeFormat
 	}
 	h.noColor = opts.NoColor
+
+	h.Labels = [4]string{"DBG", "INF", "WRN", "ERR"}
+
+	for i := range opts.Labels {
+		if opts.Labels[i] != "" {
+			h.Labels[i] = opts.Labels[i]
+		}
+	}
+
 	return h
 }
 
@@ -144,6 +156,8 @@ type handler struct {
 	replaceAttr func([]string, slog.Attr) slog.Attr
 	timeFormat  string
 	noColor     bool
+
+	Labels [4]string
 }
 
 func (h *handler) clone() *handler {
@@ -303,21 +317,21 @@ func (h *handler) appendLevel(buf *buffer, level slog.Level) {
 
 	switch {
 	case level < slog.LevelInfo:
-		buf.WriteString("DBG")
+		buf.WriteString(h.Labels[0])
 		delta(buf, level-slog.LevelDebug)
 	case level < slog.LevelWarn:
 		buf.WriteStringIf(!h.noColor, ansiBrightGreen)
-		buf.WriteString("INF")
+		buf.WriteString(h.Labels[1])
 		delta(buf, level-slog.LevelInfo)
 		buf.WriteStringIf(!h.noColor, ansiReset)
 	case level < slog.LevelError:
 		buf.WriteStringIf(!h.noColor, ansiBrightYellow)
-		buf.WriteString("WRN")
+		buf.WriteString(h.Labels[2])
 		delta(buf, level-slog.LevelWarn)
 		buf.WriteStringIf(!h.noColor, ansiReset)
 	default:
 		buf.WriteStringIf(!h.noColor, ansiBrightRed)
-		buf.WriteString("ERR")
+		buf.WriteString(h.Labels[3])
 		delta(buf, level-slog.LevelError)
 		buf.WriteStringIf(!h.noColor, ansiReset)
 	}

--- a/handler.go
+++ b/handler.go
@@ -116,7 +116,9 @@ func NewHandler(w io.Writer, opts *Options) slog.Handler {
 		w:          w,
 		level:      defaultLevel,
 		timeFormat: defaultTimeFormat,
+		Labels:     [4]string{"DBG", "INF", "WRN", "ERR"},
 	}
+
 	if opts == nil {
 		return h
 	}
@@ -130,8 +132,6 @@ func NewHandler(w io.Writer, opts *Options) slog.Handler {
 		h.timeFormat = opts.TimeFormat
 	}
 	h.noColor = opts.NoColor
-
-	h.Labels = [4]string{"DBG", "INF", "WRN", "ERR"}
 
 	for i := range opts.Labels {
 		if opts.Labels[i] != "" {
@@ -171,6 +171,7 @@ func (h *handler) clone() *handler {
 		replaceAttr: h.replaceAttr,
 		timeFormat:  h.timeFormat,
 		noColor:     h.noColor,
+		Labels:      h.Labels,
 	}
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -108,7 +108,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "val")
 			},
-			Want: `Nov 10 23:00:00.000 INFO tint/handler_test.go:99 test key=val`,
+			Want: `Nov 10 23:00:00.000 INFO tint/handler_test.go:109 test key=val`,
 		},
 		{
 			Opts: &tint.Options{

--- a/handler_test.go
+++ b/handler_test.go
@@ -102,6 +102,16 @@ func TestHandler(t *testing.T) {
 		},
 		{
 			Opts: &tint.Options{
+				AddSource: true,
+				Labels:    [4]string{"DEBUG", "INFO", "WARN", "ERROR"},
+			},
+			F: func(l *slog.Logger) {
+				l.Info("test", "key", "val")
+			},
+			Want: `Nov 10 23:00:00.000 INFO tint/handler_test.go:99 test key=val`,
+		},
+		{
+			Opts: &tint.Options{
 				TimeFormat: time.Kitchen,
 			},
 			F: func(l *slog.Logger) {


### PR DESCRIPTION
Small change gives the caller the ability to use custom labels.
For example, if they want to see "INFO" instead of "INF"

This is done by using a string array with values corresponding
to the given label in the `Options` and `handler` structs.

Instead of using the hardcoded values "DBG,INF,WRN,ERR",
these are used as default values if the relative array item
in the option happens to be an empty string.
