### PR TITLE
Fixed struct attribute name output

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -390,7 +390,7 @@ func (h *handler) appendValue(buf *buffer, v slog.Value, quote bool) {
 		case *slog.Source:
 			h.appendSource(buf, cv)
 		default:
-			appendString(buf, fmt.Sprint(v.Any()), quote)
+			appendString(buf, fmt.Sprintf("%+v", v.Any()), quote)
 		}
 	}
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -335,6 +335,15 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 10 23:00:00.000 ERR test group.err=fail`,
 		},
+		{ // https://github.com/lmittmann/tint/issues/55
+			F: func(l *slog.Logger) {
+				l.Info("test", "key", struct {
+					A int
+					B *string
+				}{A: 123})
+			},
+			Want: `Nov 10 23:00:00.000 INF test key="{A:123 B:<nil>}"`,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This PR fixes the output of structs to include their attribute names as `slog.TextHandler` does.

resolves #55