### PR TITLE
Preserve `tint.Err` attribute key

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -345,7 +345,7 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string, g
 		}
 	} else if err, ok := attr.Value.Any().(tintError); ok {
 		// append tintError
-		h.appendTintError(buf, err, groupsPrefix)
+		h.appendTintError(buf, err, attr.Key, groupsPrefix)
 		buf.WriteByte(' ')
 	} else {
 		h.appendKey(buf, attr.Key, groupsPrefix)
@@ -395,9 +395,9 @@ func (h *handler) appendValue(buf *buffer, v slog.Value, quote bool) {
 	}
 }
 
-func (h *handler) appendTintError(buf *buffer, err error, groupsPrefix string) {
+func (h *handler) appendTintError(buf *buffer, err error, attrKey, groupsPrefix string) {
 	buf.WriteStringIf(!h.noColor, ansiBrightRedFaint)
-	appendString(buf, groupsPrefix+errKey, true)
+	appendString(buf, groupsPrefix+attrKey, true)
 	buf.WriteByte('=')
 	buf.WriteStringIf(!h.noColor, ansiResetFaint)
 	appendString(buf, err.Error(), true)

--- a/handler_test.go
+++ b/handler_test.go
@@ -271,6 +271,14 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 10 23:00:00.000 ERR test err=<nil>`,
 		},
+		{ // preserve the error attribute name
+			F: func(l *slog.Logger) {
+				te := tint.Err(errors.New("something bad happens"))
+				te.Key = "Error"
+				l.Error("test", te)
+			},
+			Want: `Nov 10 23:00:00.000 ERR test Error="something bad happens"`,
+		},
 		{ // https://github.com/lmittmann/tint/pull/26
 			Opts: &tint.Options{
 				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
@@ -326,7 +334,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:327 test`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:335 test`,
 		},
 		{ // https://github.com/lmittmann/tint/issues/44
 			F: func(l *slog.Logger) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -271,14 +271,6 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 10 23:00:00.000 ERR test err=<nil>`,
 		},
-		{ // preserve the error attribute name
-			F: func(l *slog.Logger) {
-				te := tint.Err(errors.New("something bad happens"))
-				te.Key = "Error"
-				l.Error("test", te)
-			},
-			Want: `Nov 10 23:00:00.000 ERR test Error="something bad happens"`,
-		},
 		{ // https://github.com/lmittmann/tint/pull/26
 			Opts: &tint.Options{
 				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
@@ -334,7 +326,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:335 test`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:327 test`,
 		},
 		{ // https://github.com/lmittmann/tint/issues/44
 			F: func(l *slog.Logger) {
@@ -351,6 +343,14 @@ func TestHandler(t *testing.T) {
 				}{A: 123})
 			},
 			Want: `Nov 10 23:00:00.000 INF test key="{A:123 B:<nil>}"`,
+		},
+		{ // https://github.com/lmittmann/tint/pull/66
+			F: func(l *slog.Logger) {
+				errAttr := tint.Err(errors.New("fail"))
+				errAttr.Key = "error"
+				l.Error("test", errAttr)
+			},
+			Want: `Nov 10 23:00:00.000 ERR test error=fail`,
 		},
 	}
 


### PR DESCRIPTION
We do not always have control over how attribute names are defined. However, it is beneficial to highlight errors in development logs for better visibility.

For example, we heavily rely on Temporal, and modifying attribute names in that context appears inconsistent.

```
2024-07-10T13:08:55Z ERR Activity error. 
   Namespace=dev-kwargs TaskQueue= WorkerID=1@kwargs- 
   WorkflowID=7bda7d48 ActivityType=DeleteCluster Attempt=8 
   err="list clusters with name filter:  rpc error: code = PermissionDenied desc = Permission denied"
```
