### PR TITLE
enabled built-in go error formatting instead of requriring tintErr wrapping, colorized debug level text to increase readability

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -72,12 +72,10 @@ const (
 	ansiFaint          = "\033[2m"
 	ansiResetFaint     = "\033[22m"
 	ansiBrightRed      = "\033[91m"
+	ansiBrightRedFaint = "\033[91;2m"
 	ansiBrightGreen    = "\033[92m"
 	ansiBrightYellow   = "\033[93m"
-	ansiBrightRedFaint = "\033[91;2m"
 )
-
-const errKey = "err"
 
 var (
 	defaultLevel      = slog.LevelInfo
@@ -343,9 +341,9 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string, g
 		for _, groupAttr := range attr.Value.Group() {
 			h.appendAttr(buf, groupAttr, groupsPrefix, groups)
 		}
-	} else if err, ok := attr.Value.Any().(tintError); ok {
+	} else if err, ok := attr.Value.Any().(error); ok {
 		// append tintError
-		h.appendTintError(buf, err, groupsPrefix)
+		h.appendTintError(buf, attr.Key, err, groupsPrefix)
 		buf.WriteByte(' ')
 	} else {
 		h.appendKey(buf, attr.Key, groupsPrefix)
@@ -395,9 +393,9 @@ func (h *handler) appendValue(buf *buffer, v slog.Value, quote bool) {
 	}
 }
 
-func (h *handler) appendTintError(buf *buffer, err error, groupsPrefix string) {
+func (h *handler) appendTintError(buf *buffer, key string, err error, groupsPrefix string) {
 	buf.WriteStringIf(!h.noColor, ansiBrightRedFaint)
-	appendString(buf, groupsPrefix+errKey, true)
+	appendString(buf, groupsPrefix+key, true)
 	buf.WriteByte('=')
 	buf.WriteStringIf(!h.noColor, ansiResetFaint)
 	appendString(buf, err.Error(), true)
@@ -434,5 +432,5 @@ func Err(err error) slog.Attr {
 	if err != nil {
 		err = tintError{err}
 	}
-	return slog.Any(errKey, err)
+	return slog.Any("err", err)
 }

--- a/handler.go
+++ b/handler.go
@@ -346,7 +346,7 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string, g
 		}
 	} else if err, ok := attr.Value.Any().(error); ok {
 		// append tintError
-		h.appendTintError(buf, attr.Key, err, groupsPrefix)
+		h.appendTintError(buf, err, attr.Key, groupsPrefix)
 		buf.WriteByte(' ')
 	} else {
 		h.appendKey(buf, attr.Key, groupsPrefix)
@@ -396,9 +396,9 @@ func (h *handler) appendValue(buf *buffer, v slog.Value, quote bool) {
 	}
 }
 
-func (h *handler) appendTintError(buf *buffer, key string, err error, groupsPrefix string) {
+func (h *handler) appendTintError(buf *buffer, err error, attrKey, groupsPrefix string) {
 	buf.WriteStringIf(!h.noColor, ansiBrightRedFaint)
-	appendString(buf, groupsPrefix+key, true)
+	appendString(buf, groupsPrefix+attrKey, true)
 	buf.WriteByte('=')
 	buf.WriteStringIf(!h.noColor, ansiResetFaint)
 	appendString(buf, err.Error(), true)

--- a/handler.go
+++ b/handler.go
@@ -68,13 +68,14 @@ import (
 
 // ANSI modes
 const (
-	ansiReset          = "\033[0m"
-	ansiFaint          = "\033[2m"
-	ansiResetFaint     = "\033[22m"
-	ansiBrightRed      = "\033[91m"
-	ansiBrightRedFaint = "\033[91;2m"
-	ansiBrightGreen    = "\033[92m"
-	ansiBrightYellow   = "\033[93m"
+	ansiReset              = "\033[0m"
+	ansiFaint              = "\033[2m"
+	ansiBrightMagentaFaint = "\033[95;2m"
+	ansiResetFaint         = "\033[22m"
+	ansiBrightRed          = "\033[91m"
+	ansiBrightRedFaint     = "\033[91;2m"
+	ansiBrightGreen        = "\033[92m"
+	ansiBrightYellow       = "\033[93m"
 )
 
 var (
@@ -283,8 +284,10 @@ func (h *handler) appendTime(buf *buffer, t time.Time) {
 func (h *handler) appendLevel(buf *buffer, level slog.Level) {
 	switch {
 	case level < slog.LevelInfo:
+		buf.WriteStringIf(!h.noColor, ansiBrightMagentaFaint)
 		buf.WriteString("DBG")
 		appendLevelDelta(buf, level-slog.LevelDebug)
+		buf.WriteStringIf(!h.noColor, ansiReset)
 	case level < slog.LevelWarn:
 		buf.WriteStringIf(!h.noColor, ansiBrightGreen)
 		buf.WriteString("INF")

--- a/handler_test.go
+++ b/handler_test.go
@@ -28,6 +28,7 @@ func Example() {
 	slog.Debug("Connected to DB", "db", "myapp", "host", "localhost:5432")
 	slog.Warn("Slow request", "method", "GET", "path", "/users", "duration", 497*time.Millisecond)
 	slog.Error("DB connection lost", tint.Err(errors.New("connection reset")), "db", "myapp")
+	slog.Error("Flux capacitor gone", slog.Any("fail", errors.New("arbitrary error passed")), "engine", 42)
 	// Output:
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -100,7 +100,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "val")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:100 test key=val`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:101 test key=val`,
 		},
 		{
 			Opts: &tint.Options{
@@ -327,7 +327,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:327 test`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:328 test`,
 		},
 		{ // https://github.com/lmittmann/tint/issues/44
 			F: func(l *slog.Logger) {


### PR DESCRIPTION
Thank you this nice package, since moving to slog I was missing the pretty zerolog-like output. Until I discovered tint :)!

PR summary:

* **bugfix/feature [45f85b4332dd6db4f3428d8b6dd319edde5bd961]:** without resorting to the package provided `tintErr` error type wrapper, users using the native slog API to log errors didn't get colorized/red output for error messages.
By asserting the built-in `error` interface directly, both the tintErr and any other errors (satisfying the `error` interface) get the colorization treatment, also regardless of the key provided for the error value.
This kinda makes the whole `tintError` type obsolete (and I would recommend removing it altogether eventually), but I left it in for backwards compatibility in case users of this package called `tint.Err(err)` in their business logic or own package wrappers. Using the native slog API is certainly more portable, as one doesn't need to provide a wrapper package for slog and/or tint in that case.

  Preview:
  ![Screenshot_20240710_175030](https://github.com/lmittmann/tint/assets/715243/99b42a31-0029-4025-93bb-1b916996ef75)



* **feature [3fbd1c23bc3bd4c79d4c68e630b88a09dc777416]:** added faint magenta as a foreground color for debug messages, to visually isolate the DBG level text better from the log message text that follows -> increases readability when glancing over output and increases :rainbow:  level

  Preview:
  ![Screenshot_20240710_175712](https://github.com/lmittmann/tint/assets/715243/bc6b1e99-ecc8-4a4c-b8ce-8f918536d75b)
