### PR TITLE
Avoid allocating tintError twice

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -413,7 +413,7 @@ func (h *handler) appendValue(buf *buffer, v slog.Value, quote bool) {
 	}
 }
 
-func (h *handler) appendTintError(buf *buffer, err error, attrKey, groupsPrefix string) {
+func (h *handler) appendTintError(buf *buffer, err tintError, attrKey, groupsPrefix string) {
 	buf.WriteStringIf(!h.noColor, ansiBrightRedFaint)
 	appendString(buf, groupsPrefix+attrKey, true)
 	buf.WriteByte('=')

--- a/handler_test.go
+++ b/handler_test.go
@@ -554,6 +554,14 @@ func BenchmarkLogAttrs(b *testing.B) {
 				)
 			},
 		},
+		{
+			"error",
+			func(logger *slog.Logger) {
+				logger.LogAttrs(context.TODO(), slog.LevelError, testMessage,
+					tint.Err(errTest),
+				)
+			},
+		},
 	}
 
 	for _, h := range handler {


### PR DESCRIPTION
Passing the type-asserted `tintError` value as an error causes a second allocation.

Since the helper method is only for `tintError` values, change the signature to specify the concrete type to elide the second allocation.