### PR TITLE
Only convert to any on KindAny values

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -356,7 +356,6 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string, g
 	switch attr.Value.Kind() {
 	case slog.KindAny:
 		if err, ok := attr.Value.Any().(tintError); ok {
-			// append tintError
 			h.appendTintError(buf, err, attr.Key, groupsPrefix)
 			buf.WriteByte(' ')
 			return

--- a/handler.go
+++ b/handler.go
@@ -353,7 +353,15 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string, g
 		return
 	}
 
-	if attr.Value.Kind() == slog.KindGroup {
+	switch attr.Value.Kind() {
+	case slog.KindAny:
+		if err, ok := attr.Value.Any().(tintError); ok {
+			// append tintError
+			h.appendTintError(buf, err, attr.Key, groupsPrefix)
+			buf.WriteByte(' ')
+			return
+		}
+	case slog.KindGroup:
 		if attr.Key != "" {
 			groupsPrefix += attr.Key + "."
 			groups = append(groups, attr.Key)
@@ -361,15 +369,12 @@ func (h *handler) appendAttr(buf *buffer, attr slog.Attr, groupsPrefix string, g
 		for _, groupAttr := range attr.Value.Group() {
 			h.appendAttr(buf, groupAttr, groupsPrefix, groups)
 		}
-	} else if err, ok := attr.Value.Any().(tintError); ok {
-		// append tintError
-		h.appendTintError(buf, err, attr.Key, groupsPrefix)
-		buf.WriteByte(' ')
-	} else {
-		h.appendKey(buf, attr.Key, groupsPrefix)
-		h.appendValue(buf, attr.Value, true)
-		buf.WriteByte(' ')
+		return
 	}
+
+	h.appendKey(buf, attr.Key, groupsPrefix)
+	h.appendValue(buf, attr.Value, true)
+	buf.WriteByte(' ')
 }
 
 func (h *handler) appendKey(buf *buffer, key, groups string) {


### PR DESCRIPTION
Indiscriminately calling `slog.Value.Any()` on the value causes extra allocations for non-any values. Benchmark shows that for each string attribute, an extra 16-byte allocation is incurred.

This commit adds a check so `Any()` is only called on values of `KindAny`.