### PR TITLE
add colored attributes: `tint.Attr(color, attr)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ const LevelTrace = slog.LevelDebug - 4
 
 w := os.Stderr
 logger := slog.New(tint.NewHandler(w, &tint.Options{
-	Level: LevelTrace,
-	ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-		if a.Key == slog.LevelKey && len(groups) == 0 {
-			level, ok := a.Value.Any().(slog.Level)
-			if ok && level <= LevelTrace {
-				return tint.Attr(13, slog.String(a.Key, "TRC"))
-			}
-		}
-		return a
-	},
+    Level: LevelTrace,
+    ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+        if a.Key == slog.LevelKey && len(groups) == 0 {
+            level, ok := a.Value.Any().(slog.Level)
+            if ok && level <= LevelTrace {
+                return tint.Attr(13, slog.String(a.Key, "TRC"))
+            }
+        }
+        return a
+    },
 }))
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ go get github.com/lmittmann/tint
 ```go
 w := os.Stderr
 
-// create a new logger
+// Create a new logger
 logger := slog.New(tint.NewHandler(w, nil))
 
-// set global logger with custom options
+// Set global logger with custom options
 slog.SetDefault(slog.New(
     tint.NewHandler(w, &tint.Options{
         Level:      slog.LevelDebug,
@@ -46,7 +46,7 @@ each non-group attribute before it is logged. See [`slog.HandlerOptions`](https:
 for details.
 
 ```go
-// create a new logger with a custom TRACE level:
+// Create a new logger with a custom TRACE level:
 const LevelTrace = slog.LevelDebug - 4
 
 w := os.Stderr
@@ -65,7 +65,7 @@ logger := slog.New(tint.NewHandler(w, &tint.Options{
 ```
 
 ```go
-// create a new logger that doesn't write the time
+// Create a new logger that doesn't write the time
 w := os.Stderr
 logger := slog.New(
     tint.NewHandler(w, &tint.Options{
@@ -80,7 +80,7 @@ logger := slog.New(
 ```
 
 ```go
-// create a new logger that writes all errors in red
+// Create a new logger that writes all errors in red
 w := os.Stderr
 logger := slog.New(
     tint.NewHandler(w, &tint.Options{
@@ -100,7 +100,7 @@ logger := slog.New(
 
 Colors are enabled by default. Use the `Options.NoColor` field to disable
 color output. To automatically enable colors based on terminal capabilities, use
-e.g. the [`go-isatty`](https://github.com/mattn/go-isatty) package:
+e.g., the [`go-isatty`](https://github.com/mattn/go-isatty) package:
 
 ```go
 w := os.Stderr
@@ -113,7 +113,7 @@ logger := slog.New(
 
 ### Windows Support
 
-Color support on Windows can be added by using e.g. the
+Color support on Windows can be added by using e.g., the
 [`go-colorable`](https://github.com/mattn/go-colorable) package:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ logger := slog.New(
 
 ### Automatically Enable Colors
 
-Colors are enabled by default. Use the Options.NoColor field to disable
+Colors are enabled by default. Use the `Options.NoColor` field to disable
 color output. To automatically enable colors based on terminal capabilities, use
 e.g. the [`go-isatty`](https://github.com/mattn/go-isatty) package:
 

--- a/buffer.go
+++ b/buffer.go
@@ -23,6 +23,7 @@ func (b *buffer) Free() {
 		bufPool.Put(b)
 	}
 }
+
 func (b *buffer) Write(bytes []byte) (int, error) {
 	*b = append(*b, bytes...)
 	return len(bytes), nil
@@ -36,11 +37,4 @@ func (b *buffer) WriteByte(char byte) error {
 func (b *buffer) WriteString(str string) (int, error) {
 	*b = append(*b, str...)
 	return len(str), nil
-}
-
-func (b *buffer) WriteStringIf(ok bool, str string) (int, error) {
-	if !ok {
-		return 0, nil
-	}
-	return b.WriteString(str)
 }

--- a/handler.go
+++ b/handler.go
@@ -697,7 +697,7 @@ type tintValue struct {
 	slog.Value
 }
 
-// LogValue implements [slog.LogValuer].
+// LogValue implements the [slog.LogValuer] interface.
 func (v tintValue) LogValue() slog.Value {
 	return v.Value
 }
@@ -711,12 +711,10 @@ func Err(err error) slog.Attr {
 }
 
 // Attr returns a tinted (colorized) [slog.Attr] that will be written in the
-// specified color. When used with any other [slog.Handler], it behaves as a
+// specified color by the [tint.Handler]. When used with any other [slog.Handler], it behaves as a
 // plain [slog.Attr].
 //
-// # Colors
-//
-// Use the uint8 color value to specify the color of the attribute.
+// Use the uint8 color value to specify the color of the attribute:
 //
 //   - 0-7: standard ANSI colors
 //   - 8-15: high intensity ANSI colors

--- a/handler.go
+++ b/handler.go
@@ -384,7 +384,7 @@ func appendSource(buf *buffer, src *slog.Source) {
 func (h *handler) resolve(val slog.Value) (resolvedVal slog.Value, color int16) {
 	if !h.noColor && val.Kind() == slog.KindLogValuer {
 		if tintVal, ok := val.Any().(tintValue); ok {
-			return tintVal.Value.Resolve(), int16(tintVal.color)
+			return tintVal.Value.Resolve(), int16(tintVal.Color)
 		}
 	}
 	return val.Resolve(), -1
@@ -693,8 +693,8 @@ var safeSet = [utf8.RuneSelf]bool{
 }
 
 type tintValue struct {
-	color uint8
 	slog.Value
+	Color uint8
 }
 
 // LogValue implements the [slog.LogValuer] interface.
@@ -723,6 +723,6 @@ func Err(err error) slog.Attr {
 //
 // See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
 func Attr(color uint8, attr slog.Attr) slog.Attr {
-	attr.Value = slog.AnyValue(tintValue{color: color, Value: attr.Value})
+	attr.Value = slog.AnyValue(tintValue{attr.Value, color})
 	return attr
 }

--- a/handler.go
+++ b/handler.go
@@ -373,7 +373,7 @@ func appendSource(buf *buffer, src *slog.Source) {
 }
 
 func (h *handler) resolve(val slog.Value) (resolvedVal slog.Value, color int16) {
-	if !h.noColor && val.Kind() == slog.KindAny {
+	if !h.noColor && val.Kind() == slog.KindLogValuer {
 		if tintVal, ok := val.Any().(tintValue); ok {
 			return tintVal.Value.Resolve(), int16(tintVal.color)
 		}

--- a/handler.go
+++ b/handler.go
@@ -373,7 +373,7 @@ func appendSource(buf *buffer, src *slog.Source) {
 }
 
 func (h *handler) resolve(val slog.Value) (resolvedVal slog.Value, color int16) {
-	if !h.noColor {
+	if !h.noColor && val.Kind() == slog.KindAny {
 		if tintVal, ok := val.Any().(tintValue); ok {
 			return tintVal.Value.Resolve(), int16(tintVal.color)
 		}

--- a/handler.go
+++ b/handler.go
@@ -64,7 +64,7 @@ Create a new logger that writes all errors in red:
 
 Colors are enabled by default. Use the Options.NoColor field to disable
 color output. To automatically enable colors based on terminal capabilities, use
-e.g. the [go-isatty] package:
+e.g., the [go-isatty] package:
 
 	w := os.Stderr
 	logger := slog.New(
@@ -75,7 +75,7 @@ e.g. the [go-isatty] package:
 
 # Windows Support
 
-Color support on Windows can be added by using e.g. the [go-colorable] package:
+Color support on Windows can be added by using e.g., the [go-colorable] package:
 
 	w := os.Stderr
 	logger := slog.New(

--- a/handler.go
+++ b/handler.go
@@ -718,5 +718,6 @@ func Err(err error) slog.Attr {
 //
 // See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
 func Attr(color uint8, attr slog.Attr) slog.Attr {
-	return slog.Any(attr.Key, tintValue{color: color, Value: attr.Value})
+	attr.Value = slog.AnyValue(tintValue{color: color, Value: attr.Value})
+	return attr
 }

--- a/handler.go
+++ b/handler.go
@@ -700,7 +700,7 @@ func (v tintValue) LogValue() slog.Value {
 //
 //	slog.Any("err", err)
 func Err(err error) slog.Attr {
-	return Any(9, errKey, err)
+	return Attr(9, slog.Any(errKey, err))
 }
 
 // Attr returns a tinted (colorized) [slog.Attr] that will be written in the
@@ -719,44 +719,4 @@ func Err(err error) slog.Attr {
 // See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
 func Attr(color uint8, attr slog.Attr) slog.Attr {
 	return slog.Any(attr.Key, tintValue{color: color, Value: attr.Value})
-}
-
-func Any(color uint8, key string, value any) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.AnyValue(value)})
-}
-
-func String(color uint8, key, value string) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.StringValue(value)})
-}
-
-func Int(color uint8, key string, value int) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.IntValue(value)})
-}
-
-func Int64(color uint8, key string, value int64) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.Int64Value(value)})
-}
-
-func Uint64(color uint8, key string, value uint64) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.Uint64Value(value)})
-}
-
-func Float64(color uint8, key string, value float64) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.Float64Value(value)})
-}
-
-func Bool(color uint8, key string, value bool) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.BoolValue(value)})
-}
-
-func Time(color uint8, key string, value time.Time) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.TimeValue(value)})
-}
-
-func Duration(color uint8, key string, value time.Duration) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.DurationValue(value)})
-}
-
-func Group(color uint8, key string, attrs ...slog.Attr) slog.Attr {
-	return slog.Any(key, tintValue{color: color, Value: slog.GroupValue(attrs...)})
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -586,13 +586,17 @@ func TestReplaceAttr(t *testing.T) {
 	}
 }
 
-func TestErr(t *testing.T) {
+func TestAttr(t *testing.T) {
+	if !faketime.Equal(time.Now()) {
+		t.Skip(`skipping test; run with "-tags=faketime"`)
+	}
+
 	t.Run("text", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewTextHandler(&buf, nil))
-		logger.Info("test", tint.Err(errTest))
+		logger.Info("test", tint.Attr(10, slog.String("key", "val")))
 
-		want := `time=2009-11-10T23:00:00.000Z level=INFO msg=test err=fail`
+		want := `time=2009-11-10T23:00:00.000Z level=INFO msg=test key=val`
 		if got := strings.TrimSpace(buf.String()); want != got {
 			t.Fatalf("(-want +got)\n- %s\n+ %s", want, got)
 		}
@@ -601,9 +605,9 @@ func TestErr(t *testing.T) {
 	t.Run("json", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewJSONHandler(&buf, nil))
-		logger.Info("test", tint.Err(errTest))
+		logger.Info("test", tint.Attr(10, slog.String("key", "val")))
 
-		want := `{"time":"2009-11-10T23:00:00Z","level":"INFO","msg":"test","err":"fail"}`
+		want := `{"time":"2009-11-10T23:00:00Z","level":"INFO","msg":"test","key":"val"}`
 		if got := strings.TrimSpace(buf.String()); want != got {
 			t.Fatalf("(-want +got)\n- %s\n+ %s", want, got)
 		}

--- a/handler_test.go
+++ b/handler_test.go
@@ -547,6 +547,30 @@ func TestHandler(t *testing.T) {
 			},
 			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[95mTRC\033[0m test",
 		},
+		{
+			F: func(l *slog.Logger) {
+				l.Info("test", "lvl", slog.LevelWarn)
+			},
+			Want: `Nov 10 23:00:00.000 INF test lvl=WARN`,
+		},
+		{
+			Opts: &tint.Options{NoColor: false},
+			F: func(l *slog.Logger) {
+				l.Info("test", "lvl", slog.LevelWarn)
+			},
+			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m test \033[2mlvl=\033[0mWARN",
+		},
+		{
+			Opts: &tint.Options{
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					return tint.Attr(13, a)
+				},
+			},
+			F: func(l *slog.Logger) {
+				l.Info("test")
+			},
+			Want: "\033[2;95mNov 10 23:00:00.000\033[0m \033[95mINF\033[0m \033[95mtest\033[0m",
+		},
 	}
 
 	for i, test := range tests {
@@ -812,18 +836,6 @@ func BenchmarkLogAttrs(b *testing.B) {
 		})
 	}
 }
-
-// func TestTint(t *testing.T) {
-// 	slog.SetDefault(slog.New(tint.NewHandler(os.Stderr, &tint.Options{
-// 		Level:      slog.LevelDebug,
-// 		TimeFormat: time.Kitchen,
-// 	})))
-
-// 	for i := 0; i < 256; i++ {
-// 		s := strings.Repeat(strconv.Itoa(int(i))+" ", 6)[:11]
-// 		slog.Info("test", tint.Attr(uint8(i), slog.String("color", s)), "nocolor", "123")
-// 	}
-// }
 
 // discarder is a slog.Handler that discards all records.
 type discarder struct{}

--- a/handler_test.go
+++ b/handler_test.go
@@ -433,14 +433,14 @@ func TestHandler(t *testing.T) {
 		{
 			Opts: &tint.Options{NoColor: false},
 			F: func(l *slog.Logger) {
-				l.Info("test", tint.String(10, "key", "value"))
+				l.Info("test", tint.Attr(10, slog.String("key", "value")))
 			},
 			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m test \033[2;92mkey=\033[22mvalue\033[0m",
 		},
 		{
 			Opts: &tint.Options{NoColor: false},
 			F: func(l *slog.Logger) {
-				l.Info("test", tint.String(226, "key", "value"))
+				l.Info("test", tint.Attr(226, slog.String("key", "value")))
 			},
 			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m test \033[2;38;5;226mkey=\033[22mvalue\033[0m",
 		},
@@ -479,7 +479,7 @@ func TestHandler(t *testing.T) {
 				NoColor: false,
 				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 					if a.Key == slog.TimeKey && len(groups) == 0 {
-						return tint.String(10, a.Key, a.Value.Time().Format(time.StampMilli))
+						return tint.Attr(10, slog.String(a.Key, a.Value.Time().Format(time.StampMilli)))
 					}
 					return a
 				},
@@ -536,7 +536,7 @@ func TestHandler(t *testing.T) {
 						if !ok || level > slog.LevelDebug-4 {
 							return a
 						}
-						return tint.String(13, a.Key, "TRC")
+						return tint.Attr(13, slog.String(a.Key, "TRC"))
 					}
 					return a
 				},

--- a/handler_test.go
+++ b/handler_test.go
@@ -432,7 +432,7 @@ func TestHandler(t *testing.T) {
 				},
 			},
 			F: func(l *slog.Logger) {
-				var levelTrace slog.Level = slog.LevelDebug - 4
+				const levelTrace = slog.LevelDebug - 4
 				l.Log(context.TODO(), levelTrace, "test")
 			},
 			Want: "\033[2mNov 10 23:00:00.000\033[0m TRC test",
@@ -452,7 +452,7 @@ func TestHandler(t *testing.T) {
 				},
 			},
 			F: func(l *slog.Logger) {
-				var levelTrace slog.Level = slog.LevelDebug - 4
+				const levelTrace = slog.LevelDebug - 4
 				l.Log(context.TODO(), levelTrace, "test")
 			},
 			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[95mTRC\033[0m test",

--- a/handler_test.go
+++ b/handler_test.go
@@ -441,14 +441,14 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "value")
 			},
-			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m \033[92mtest\033[0m \033[2mkey=\033[22mvalue\033[0m",
+			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m \033[92mtest\033[0m \033[2mkey=\033[0mvalue",
 		},
 		{
 			Opts: &tint.Options{
 				NoColor: false,
 				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 					if a.Key == slog.TimeKey && len(groups) == 0 {
-						return tint.Time(10, slog.MessageKey, a.Value.Time())
+						return tint.Time(10, slog.TimeKey, a.Value.Time())
 					}
 					return a
 				},
@@ -456,7 +456,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "value")
 			},
-			Want: "\033[2;92mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m test \033[2mkey=\033[22mvalue\033[0m",
+			Want: "\033[2;92mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m test \033[2mkey=\033[0mvalue",
 		},
 	}
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -257,6 +257,22 @@ func TestHandler(t *testing.T) {
 			},
 			Want: `Nov 10 23:00:00.000 INF test ""=""`,
 		},
+		{
+			Opts: &tint.Options{
+				TimeFormat: time.DateOnly,
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if len(groups) == 0 && a.Key == slog.TimeKey {
+						return slog.Time(slog.TimeKey, a.Value.Time().Add(24*time.Hour))
+					}
+					return a
+				},
+				NoColor: true,
+			},
+			F: func(l *slog.Logger) {
+				l.Info("test")
+			},
+			Want: `2009-11-11 INF test`,
+		},
 
 		{ // https://github.com/lmittmann/tint/issues/8
 			F: func(l *slog.Logger) {
@@ -345,7 +361,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:346 test`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:361 test`,
 		},
 		{ // https://github.com/lmittmann/tint/issues/44
 			F: func(l *slog.Logger) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -361,7 +361,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:361 test`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:362 test`,
 		},
 		{ // https://github.com/lmittmann/tint/issues/44
 			F: func(l *slog.Logger) {
@@ -449,7 +449,7 @@ func TestHandler(t *testing.T) {
 				NoColor: false,
 				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 					if a.Key == slog.MessageKey && len(groups) == 0 {
-						return tint.String(10, slog.MessageKey, a.String())
+						return tint.Attr(10, a)
 					}
 					return a
 				},
@@ -464,7 +464,22 @@ func TestHandler(t *testing.T) {
 				NoColor: false,
 				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 					if a.Key == slog.TimeKey && len(groups) == 0 {
-						return tint.Time(10, slog.TimeKey, a.Value.Time())
+						return tint.Attr(10, a)
+					}
+					return a
+				},
+			},
+			F: func(l *slog.Logger) {
+				l.Info("test", "key", "value")
+			},
+			Want: "\033[2;92mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m test \033[2mkey=\033[0mvalue",
+		},
+		{
+			Opts: &tint.Options{
+				NoColor: false,
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.TimeKey && len(groups) == 0 {
+						return tint.String(10, a.Key, a.Value.Time().Format(time.StampMilli))
 					}
 					return a
 				},

--- a/handler_test.go
+++ b/handler_test.go
@@ -489,6 +489,64 @@ func TestHandler(t *testing.T) {
 			},
 			Want: "\033[2;92mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m test \033[2mkey=\033[0mvalue",
 		},
+		{
+			Opts: &tint.Options{
+				AddSource: true,
+				NoColor:   false,
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.SourceKey && len(groups) == 0 {
+						return tint.Attr(10, a)
+					}
+					return a
+				},
+			},
+			F: func(l *slog.Logger) {
+				l.Info("test")
+			},
+			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m \033[2;92mtint/handler_test.go:504\033[0m test",
+		},
+		{
+			Opts: &tint.Options{
+				NoColor: false,
+				Level:   slog.LevelDebug - 4,
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.LevelKey && len(groups) == 0 {
+						level, ok := a.Value.Any().(slog.Level)
+						if !ok || level > slog.LevelDebug-4 {
+							return a
+						}
+						return slog.String(a.Key, "TRC")
+					}
+					return a
+				},
+			},
+			F: func(l *slog.Logger) {
+				var levelTrace slog.Level = slog.LevelDebug - 4
+				l.Log(context.TODO(), levelTrace, "test")
+			},
+			Want: "\033[2mNov 10 23:00:00.000\033[0m TRC test",
+		},
+		{
+			Opts: &tint.Options{
+				NoColor: false,
+				Level:   slog.LevelDebug - 4,
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.LevelKey && len(groups) == 0 {
+						level, ok := a.Value.Any().(slog.Level)
+						if !ok || level > slog.LevelDebug-4 {
+							return a
+						}
+						return tint.String(13, a.Key, "TRC")
+					}
+					return a
+				},
+			},
+			F: func(l *slog.Logger) {
+				var levelTrace slog.Level = slog.LevelDebug - 4
+				l.Log(context.TODO(), levelTrace, "test")
+			},
+			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[95mTRC\033[0m test",
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This PR adds the function `tint.Attr` to easily write colored logs:

```
func Attr(color uint8, attr slog.Attr) slog.Attr
```

Attr returns a tinted (colorized) `slog.Attr` that will be written in the
specified color by the [tint.Handler]. When used with any other [slog.Handler], it behaves as a
plain `slog.Attr`.

Use the uint8 color value to specify the color of the attribute:
  - 0-7: standard ANSI colors
  - 8-15: high intensity ANSI colors
  - 16-231: 216 colors (6×6×6 cube)
  - 232-255: grayscale from dark to light in 24 steps

See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit

### Example:

Create a new logger with a custom TRACE level:

```go
const LevelTrace = slog.LevelDebug - 4

w := os.Stderr
logger := slog.New(tint.NewHandler(w, &tint.Options{
    Level: LevelTrace,
    ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
        if a.Key == slog.LevelKey && len(groups) == 0 {
            level, ok := a.Value.Any().(slog.Level)
            if ok && level <= LevelTrace {
                return tint.Attr(13, slog.String(a.Key, "TRC"))
            }
        }
        return a
    },
}))
```

resolves #61 