### PR TITLE
Fix time attribute formating to match `slog.TextHandler`

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -470,7 +470,7 @@ func (h *handler) appendValue(buf *buffer, v slog.Value, quote bool) {
 	case slog.KindDuration:
 		appendString(buf, v.Duration().String(), quote, !h.noColor)
 	case slog.KindTime:
-		appendString(buf, v.Time().String(), quote, !h.noColor)
+		*buf = appendRFC3339Millis(*buf, v.Time())
 	case slog.KindAny:
 		defer func() {
 			// Copied from log/slog/handler.go.
@@ -481,7 +481,7 @@ func (h *handler) appendValue(buf *buffer, v slog.Value, quote bool) {
 				//
 				// Adapted from the code in fmt/print.go.
 				if v := reflect.ValueOf(v.Any()); v.Kind() == reflect.Pointer && v.IsNil() {
-					appendString(buf, "<nil>", false, false)
+					buf.WriteString("<nil>")
 					return
 				}
 
@@ -519,6 +519,20 @@ func (h *handler) appendTintValue(buf *buffer, val slog.Value, quote bool, color
 			buf.WriteString(ansiReset)
 		}
 	}
+}
+
+// Copied from log/slog/handler.go.
+func appendRFC3339Millis(b []byte, t time.Time) []byte {
+	// Format according to time.RFC3339Nano since it is highly optimized,
+	// but truncate it to use millisecond resolution.
+	// Unfortunately, that format trims trailing 0s, so add 1/10 millisecond
+	// to guarantee that there are exactly 4 digits after the period.
+	const prefixLen = len("2006-01-02T15:04:05.000")
+	n := len(b)
+	t = t.Truncate(time.Millisecond).Add(time.Millisecond / 10)
+	b = t.AppendFormat(b, time.RFC3339Nano)
+	b = append(b[:n+prefixLen], b[n+prefixLen+1:]...) // drop the 4th digit
+	return b
 }
 
 func appendAnsi(buf *buffer, color uint8, faint bool) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -730,6 +730,35 @@ func TestAttr(t *testing.T) {
 	})
 }
 
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		Args []any
+	}{
+		{},
+		{[]any{"test", testMessage}},
+		{[]any{"test", testTime}},
+		{[]any{"test", testString}},
+		{[]any{"test", testInt}},
+		{[]any{"test", testDuration}},
+		{[]any{"test", errTest}},
+	}
+
+	repl := drop(slog.TimeKey, slog.LevelKey, slog.MessageKey, slog.SourceKey)
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var textBuf, tintBuf bytes.Buffer
+			textLogger := slog.New(slog.NewTextHandler(&textBuf, &slog.HandlerOptions{ReplaceAttr: repl}))
+			tintLogger := slog.New(tint.NewHandler(&tintBuf, &tint.Options{ReplaceAttr: repl, NoColor: true}))
+			textLogger.Info("", test.Args...)
+			tintLogger.Info("", test.Args...)
+
+			if textBuf.String() != tintBuf.String() {
+				t.Fatalf("(-want +got)\ntext - %q\ntint + %q", textBuf.String(), tintBuf.String())
+			}
+		})
+	}
+}
+
 // See https://github.com/golang/exp/blob/master/slog/benchmarks/benchmarks_test.go#L25
 //
 // Run e.g.:

--- a/handler_test.go
+++ b/handler_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/lmittmann/tint"
 )
 
-var faketime = time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
-
 func Example() {
 	w := os.Stderr
 	logger := slog.New(tint.NewHandler(w, &tint.Options{
@@ -69,15 +67,10 @@ func Example_traceLevel() {
 	// Output:
 }
 
-// Run test with "faketime" tag:
-//
-//	TZ="" go test -tags=faketime
-func TestHandler(t *testing.T) {
-	if !faketime.Equal(time.Now()) {
-		t.Skip(`skipping test; run with "-tags=faketime"`)
-	}
+var (
+	faketime = time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 
-	tests := []struct {
+	handlerTests = []struct {
 		Opts *tint.Options
 		F    func(l *slog.Logger)
 		Want string
@@ -138,7 +131,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "val")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:139 test key=val`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:132 test key=val`,
 		},
 		{
 			Opts: &tint.Options{
@@ -415,7 +408,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m \033[2;92mtint/handler_test.go:416\033[0m test",
+			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m \033[2;92mtint/handler_test.go:409\033[0m test",
 		},
 		{
 			Opts: &tint.Options{
@@ -545,7 +538,7 @@ func TestHandler(t *testing.T) {
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:546 test`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:539 test`,
 		},
 		{ // https://github.com/lmittmann/tint/issues/44
 			F: func(l *slog.Logger) {
@@ -607,8 +600,14 @@ func TestHandler(t *testing.T) {
 			Want: `Nov 10 23:00:00.000 INF test time=<nil>`,
 		},
 	}
+)
 
-	for i, test := range tests {
+func TestHandler(t *testing.T) {
+	if now := time.Now(); !faketime.Equal(now) || now.Location().String() != "UTC" {
+		t.Skip(`run: TZ="" go test -tags=faketime`)
+	}
+
+	for i, test := range handlerTests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var buf bytes.Buffer
 			if test.Opts == nil {
@@ -657,8 +656,8 @@ func replace(new slog.Value, keys ...string) func([]string, slog.Attr) slog.Attr
 }
 
 func TestReplaceAttr(t *testing.T) {
-	if !faketime.Equal(time.Now()) {
-		t.Skip(`skipping test; run with "-tags=faketime"`)
+	if now := time.Now(); !faketime.Equal(now) || now.Location().String() != "UTC" {
+		t.Skip(`run: TZ="" go test -tags=faketime`)
 	}
 
 	tests := [][]any{
@@ -704,8 +703,8 @@ func TestReplaceAttr(t *testing.T) {
 }
 
 func TestAttr(t *testing.T) {
-	if !faketime.Equal(time.Now()) {
-		t.Skip(`skipping test; run with "-tags=faketime"`)
+	if now := time.Now(); !faketime.Equal(now) || now.Location().String() != "UTC" {
+		t.Skip(`run: TZ="" go test -tags=faketime`)
 	}
 
 	t.Run("text", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes an inconsistency in how time values are formatted. `tint` is meant to match the behavior of `slog.TextHandler` for log attributes beyond the standard attributes (`slog.TimeKey`...).

## Performance Improvement

```
```