### PR TITLE
Fix cloned handlers to use same mutex

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           go-version: "1.21"
       - name: test
-        run: TZ="" go test ./... -tags=faketime
+        run: TZ="" go test ./... -race -tags=faketime

--- a/handler.go
+++ b/handler.go
@@ -181,10 +181,10 @@ type handler struct {
 
 func (h *handler) clone() *handler {
 	return &handler{
-		mu:          h.mu,
 		attrsPrefix: h.attrsPrefix,
 		groupPrefix: h.groupPrefix,
 		groups:      h.groups,
+		mu:          h.mu, // mutex shared among all clones of this handler
 		w:           h.w,
 		opts:        h.opts,
 	}

--- a/handler.go
+++ b/handler.go
@@ -161,6 +161,7 @@ func NewHandler(w io.Writer, opts *Options) slog.Handler {
 	opts.setDefaults()
 
 	return &handler{
+		mu:   &sync.Mutex{},
 		w:    w,
 		opts: *opts,
 	}
@@ -172,7 +173,7 @@ type handler struct {
 	groupPrefix string
 	groups      []string
 
-	mu sync.Mutex
+	mu *sync.Mutex
 	w  io.Writer
 
 	opts Options
@@ -180,6 +181,7 @@ type handler struct {
 
 func (h *handler) clone() *handler {
 	return &handler{
+		mu:          h.mu,
 		attrsPrefix: h.attrsPrefix,
 		groupPrefix: h.groupPrefix,
 		groups:      h.groups,

--- a/handler_test.go
+++ b/handler_test.go
@@ -764,15 +764,14 @@ func TestAttr(t *testing.T) {
 	})
 }
 
-// TestClonedHandlersSynchronizeWriter tests that cloned handlers synchronize writer writes with each other
-// such that a logger can be shared among multiple goroutines.
+// TestClonedHandlersSynchronizeWriter tests that cloned handlers synchronize writer
+// writes with each other such that a logger can be shared among multiple goroutines.
 func TestClonedHandlersSynchronizeWriter(t *testing.T) {
-
 	// logSomething calls `With(...)` and uses the resulting logger to create and use a cloned handler.
-	logSomething := func(wg *sync.WaitGroup, logger *slog.Logger, loggerID string) {
+	logSomething := func(wg *sync.WaitGroup, logger *slog.Logger, loggerID int) {
 		defer wg.Done()
 		logger = logger.With("withLoggerID", loggerID)
-		logger.Info("test", "loggerID", loggerID)
+		logger.Info("test")
 	}
 
 	logger := slog.New(tint.NewHandler(&bytes.Buffer{}, &tint.Options{}))
@@ -780,8 +779,8 @@ func TestClonedHandlersSynchronizeWriter(t *testing.T) {
 	// start and wait for two goroutines
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go logSomething(&wg, logger, "1")
-	go logSomething(&wg, logger, "2")
+	go logSomething(&wg, logger, 1)
+	go logSomething(&wg, logger, 2)
 	wg.Wait()
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -131,7 +132,7 @@ var (
 			F: func(l *slog.Logger) {
 				l.Info("test", "key", "val")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:132 test key=val`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:133 test key=val`,
 		},
 		{
 			Opts: &tint.Options{
@@ -408,7 +409,7 @@ var (
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m \033[2;92mtint/handler_test.go:409\033[0m test",
+			Want: "\033[2mNov 10 23:00:00.000\033[0m \033[92mINF\033[0m \033[2;92mtint/handler_test.go:410\033[0m test",
 		},
 		{
 			Opts: &tint.Options{
@@ -538,7 +539,7 @@ var (
 			F: func(l *slog.Logger) {
 				l.Info("test")
 			},
-			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:539 test`,
+			Want: `Nov 10 23:00:00.000 INF tint/handler_test.go:540 test`,
 		},
 		{ // https://github.com/lmittmann/tint/issues/44
 			F: func(l *slog.Logger) {
@@ -761,6 +762,27 @@ func TestAttr(t *testing.T) {
 			t.Fatalf("(-want +got)\n- %s\n+ %s", want, got)
 		}
 	})
+}
+
+// TestClonedHandlersSynchronizeWriter tests that cloned handlers synchronize writer writes with each other
+// such that a logger can be shared among multiple goroutines.
+func TestClonedHandlersSynchronizeWriter(t *testing.T) {
+
+	// logSomething calls `With(...)` and uses the resulting logger to create and use a cloned handler.
+	logSomething := func(wg *sync.WaitGroup, logger *slog.Logger, loggerID string) {
+		defer wg.Done()
+		logger = logger.With("withLoggerID", loggerID)
+		logger.Info("test", "loggerID", loggerID)
+	}
+
+	logger := slog.New(tint.NewHandler(&bytes.Buffer{}, &tint.Options{}))
+
+	// start and wait for two goroutines
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go logSomething(&wg, logger, "1")
+	go logSomething(&wg, logger, "2")
+	wg.Wait()
 }
 
 // See https://github.com/golang/exp/blob/master/slog/benchmarks/benchmarks_test.go#L25


### PR DESCRIPTION
#### **Why** this PR?
We experienced a race condition being detected in a test logging to a `bytes.Buffer`. Although the problem doesn't occur when logging to `os.Stderr`, presumably because this is synchronized, it is reproducible when a logger uses a cloned handler.

#### **What** has changed?
Based on https://github.com/golang/example/blob/8b405629c4a5215871be932097e099c05ec5cb2e/slog-handler-guide/README.md#concurrency-safety, synchronization in `handler` is changed to share a mutex among all clones, similar to `slog.commonHandler` https://cs.opensource.google/go/go/+/refs/tags/go1.24.3:src/log/slog/handler.go;l=197.

#### How is it **tested**?
An explicit test triggering a race condition is added: `TestClonedHandlersSynchronizeWriter`.

#### How does it affect **users**?
There should be no effect on users.