### PR TITLE
refactor: rename NewHandler to NewTextHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ go get github.com/lmittmann/tint
 w := os.Stderr
 
 // Create a new logger
-logger := slog.New(tint.NewHandler(w, nil))
+logger := slog.New(tint.NewTextHandler(w, nil))
 
 // Set global logger with custom options
 slog.SetDefault(slog.New(
-    tint.NewHandler(w, &tint.Options{
+    tint.NewTextHandler(w, &tint.Options{
         Level:      slog.LevelDebug,
         TimeFormat: time.Kitchen,
     }),
@@ -49,7 +49,7 @@ for details.
 const LevelTrace = slog.LevelDebug - 4
 
 w := os.Stderr
-logger := slog.New(tint.NewHandler(w, &tint.Options{
+logger := slog.New(tint.NewTextHandler(w, &tint.Options{
     Level: LevelTrace,
     ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
         if a.Key == slog.LevelKey && len(groups) == 0 {
@@ -67,7 +67,7 @@ logger := slog.New(tint.NewHandler(w, &tint.Options{
 // Create a new logger that doesn't write the time
 w := os.Stderr
 logger := slog.New(
-    tint.NewHandler(w, &tint.Options{
+    tint.NewTextHandler(w, &tint.Options{
         ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
             if a.Key == slog.TimeKey && len(groups) == 0 {
                 return slog.Attr{}
@@ -82,7 +82,7 @@ logger := slog.New(
 // Create a new logger that writes all errors in red
 w := os.Stderr
 logger := slog.New(
-    tint.NewHandler(w, &tint.Options{
+    tint.NewTextHandler(w, &tint.Options{
         ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
             if a.Value.Kind() == slog.KindAny {
                 if _, ok := a.Value.Any().(error); ok {
@@ -104,7 +104,7 @@ e.g., the [`go-isatty`](https://github.com/mattn/go-isatty) package:
 ```go
 w := os.Stderr
 logger := slog.New(
-    tint.NewHandler(w, &tint.Options{
+    tint.NewTextHandler(w, &tint.Options{
         NoColor: !isatty.IsTerminal(w.Fd()),
     }),
 )
@@ -118,6 +118,6 @@ Color support on Windows can be added by using e.g., the
 ```go
 w := os.Stderr
 logger := slog.New(
-    tint.NewHandler(colorable.NewColorable(w), nil),
+    tint.NewTextHandler(colorable.NewColorable(w), nil),
 )
 ```

--- a/handler.go
+++ b/handler.go
@@ -17,7 +17,7 @@ Create a new logger with a custom TRACE level:
 	const LevelTrace = slog.LevelDebug - 4
 
 	w := os.Stderr
-	logger := slog.New(tint.NewHandler(w, &tint.Options{
+	logger := slog.New(tint.NewTextHandler(w, &tint.Options{
 		Level: LevelTrace,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.LevelKey && len(groups) == 0 {
@@ -34,7 +34,7 @@ Create a new logger that doesn't write the time:
 
 	w := os.Stderr
 	logger := slog.New(
-		tint.NewHandler(w, &tint.Options{
+		tint.NewTextHandler(w, &tint.Options{
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 				if a.Key == slog.TimeKey && len(groups) == 0 {
 					return slog.Attr{}
@@ -48,7 +48,7 @@ Create a new logger that writes all errors in red:
 
 	w := os.Stderr
 	logger := slog.New(
-		tint.NewHandler(w, &tint.Options{
+		tint.NewTextHandler(w, &tint.Options{
 			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 				if a.Value.Kind() == slog.KindAny {
 					if _, ok := a.Value.Any().(error); ok {
@@ -68,7 +68,7 @@ e.g., the [go-isatty] package:
 
 	w := os.Stderr
 	logger := slog.New(
-		tint.NewHandler(w, &tint.Options{
+		tint.NewTextHandler(w, &tint.Options{
 			NoColor: !isatty.IsTerminal(w.Fd()),
 		}),
 	)
@@ -79,7 +79,7 @@ Color support on Windows can be added by using e.g., the [go-colorable] package:
 
 	w := os.Stderr
 	logger := slog.New(
-		tint.NewHandler(colorable.NewColorable(w), nil),
+		tint.NewTextHandler(colorable.NewColorable(w), nil),
 	)
 
 [zerolog.ConsoleWriter]: https://pkg.go.dev/github.com/rs/zerolog#ConsoleWriter
@@ -152,9 +152,9 @@ func (o *Options) setDefaults() {
 	}
 }
 
-// NewHandler creates a [slog.Handler] that writes tinted logs to Writer w,
+// NewTextHandler creates a [slog.Handler] that writes tinted logs to Writer w,
 // using the default options. If opts is nil, the default options are used.
-func NewHandler(w io.Writer, opts *Options) slog.Handler {
+func NewTextHandler(w io.Writer, opts *Options) slog.Handler {
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -165,6 +165,16 @@ func NewHandler(w io.Writer, opts *Options) slog.Handler {
 		w:    w,
 		opts: *opts,
 	}
+}
+
+// NewHandler creates a [slog.Handler] that writes tinted logs to Writer w,
+// using the default options. If opts is nil, the default options are used.
+//
+// Deprecated: Use [NewTextHandler] instead.
+//
+//go:fix inline
+func NewHandler(w io.Writer, opts *Options) slog.Handler {
+	return NewTextHandler(w, opts)
 }
 
 // handler implements a [slog.Handler].

--- a/handler_test.go
+++ b/handler_test.go
@@ -20,7 +20,7 @@ import (
 
 func Example() {
 	w := os.Stderr
-	logger := slog.New(tint.NewHandler(w, &tint.Options{
+	logger := slog.New(tint.NewTextHandler(w, &tint.Options{
 		Level:      slog.LevelDebug,
 		TimeFormat: time.Kitchen,
 	}))
@@ -34,7 +34,7 @@ func Example() {
 // Create a new logger that writes all errors in red:
 func Example_redErrors() {
 	w := os.Stderr
-	logger := slog.New(tint.NewHandler(w, &tint.Options{
+	logger := slog.New(tint.NewTextHandler(w, &tint.Options{
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Value.Kind() == slog.KindAny {
 				if _, ok := a.Value.Any().(error); ok {
@@ -53,7 +53,7 @@ func Example_traceLevel() {
 	const LevelTrace = slog.LevelDebug - 4
 
 	w := os.Stderr
-	logger := slog.New(tint.NewHandler(w, &tint.Options{
+	logger := slog.New(tint.NewTextHandler(w, &tint.Options{
 		Level: LevelTrace,
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.LevelKey && len(groups) == 0 {
@@ -671,7 +671,7 @@ func TestHandler(t *testing.T) {
 			if test.Opts == nil {
 				test.Opts = &tint.Options{NoColor: true}
 			}
-			l := slog.New(tint.NewHandler(&buf, test.Opts))
+			l := slog.New(tint.NewTextHandler(&buf, test.Opts))
 			test.F(l)
 
 			got, foundNewline := strings.CutSuffix(buf.String(), "\n")
@@ -760,7 +760,7 @@ func TestHandler_Consistency(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			// log with tint.Handler
 			var tintBuf bytes.Buffer
-			tintLogger := slog.New(tint.NewHandler(&tintBuf, &tint.Options{
+			tintLogger := slog.New(tint.NewTextHandler(&tintBuf, &tint.Options{
 				NoColor:     true,
 				ReplaceAttr: rep,
 			}))
@@ -813,7 +813,7 @@ func TestReplaceAttr(t *testing.T) {
 			slogLogger.Log(context.TODO(), slog.LevelInfo, "", test...)
 
 			tintRecord := make([]replaceAttrParams, 0)
-			tintLogger := slog.New(tint.NewHandler(io.Discard, &tint.Options{
+			tintLogger := slog.New(tint.NewTextHandler(io.Discard, &tint.Options{
 				ReplaceAttr: replaceAttrRecorder(&tintRecord),
 			}))
 			tintLogger.Log(context.TODO(), slog.LevelInfo, "", test...)
@@ -865,7 +865,7 @@ func TestClonedHandlersSynchronizeWriter(t *testing.T) {
 		logger.Info("test")
 	}
 
-	logger := slog.New(tint.NewHandler(&bytes.Buffer{}, &tint.Options{}))
+	logger := slog.New(tint.NewTextHandler(&bytes.Buffer{}, &tint.Options{}))
 
 	// start and wait for two goroutines
 	var wg sync.WaitGroup
@@ -885,7 +885,7 @@ func BenchmarkLogAttrs(b *testing.B) {
 		Name string
 		H    slog.Handler
 	}{
-		{"tint", tint.NewHandler(io.Discard, nil)},
+		{"tint", tint.NewTextHandler(io.Discard, nil)},
 		{"text", slog.NewTextHandler(io.Discard, nil)},
 		{"json", slog.NewJSONHandler(io.Discard, nil)},
 		{"discard", new(discarder)},


### PR DESCRIPTION
Renames `NewHandler` to `NewTextHandler`. `NewHandler` remains as a deprecated wrapper with the same signature, so existing code keeps working.

The wrapper carries a `//go:fix inline` directive, so `go fix` (Go 1.26+) and gopls automatically rewrite `tint.NewHandler(w, opts)` call sites to `tint.NewTextHandler(w, opts)`.

Also updates all call sites in the package docs, tests, and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)